### PR TITLE
Rename internal flag purgePullZone to purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It will upload files and folders if "true" provided. source, storageZoneName and
 
 It will remove all the files from storage before uploading if "true" provided. storageZoneName and storagePassword inputs should be provided.
 
-### `purge`
+### `purgePullZone`
 
 It will purge the pull zone if "true" provided. pullZoneId and accessKey inputs should be provided.
 
@@ -58,5 +58,5 @@ Pull zone ID.
     pullZoneId: "${{ secrets.ZONE_ID }}"
     upload: "true"
     remove: "true"
-    purge: "true"
+    purgePullZone: "true"
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: "The API key."
   pullZoneId:
     description: "Is required for purging."
-  purge:
+  purgePullZone:
     description: "It will purge the pull zone if true. pullZoneId and accessKey should be provided."
     default: "false"
   remove:

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const run = async () => {
     const accessKey = getInput("accessKey");
     const pullZoneId = getInput("pullZoneId");
 
-    const purgePullZoneFlag = getInput("purgePullZone");
+    const purgePullZoneFlag = getInput("purge");
     const removeFlag = getInput("remove");
     const uploadFlag = getInput("upload");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const run = async () => {
     const accessKey = getInput("accessKey");
     const pullZoneId = getInput("pullZoneId");
 
-    const purgePullZoneFlag = getInput("purge");
+    const purgePullZoneFlag = getInput("purgePullZone");
     const removeFlag = getInput("remove");
     const uploadFlag = getInput("upload");
 


### PR DESCRIPTION
README mentions `purge`, but internally the flag `purgePullZone` is used. This commit will match the code's flag to the README's flag, which also keeps with the naming of the remove and upload flags.

Otherwise, using `purge: true` will not purge the zone. Only `purgePullZone: true`.

Potentially a breaking change for anyone using `purgePullZone:true`. Maybe allow either flag?