### PR TITLE
Update purge error when access key not set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ class Main {
         throw new Error("Can't purge, pullZoneId was not set.");
       }
       if (!this.params.accessKey) {
-        throw new Error("Can't upload, accessKey was not set.");
+        throw new Error("Can't purge, accessKey was not set.");
       }
       if (this.params.pullZoneId && this.params.accessKey) {
         info(`Purging pull zone with the id ${this.params.pullZoneId}`);


### PR DESCRIPTION
change `upload` to `purge` in error message.