### PR TITLE
fix: upload retries uploading zero byte files

### DIFF
--- a/src/test/uploader.test.ts
+++ b/src/test/uploader.test.ts
@@ -139,6 +139,7 @@ describe("Uploader", () => {
         timeoutSpy.mockRestore();
 
         expect(fetchMock).toHaveBeenCalledTimes(5);
+        expect(createReadStreamMock).toHaveBeenCalledTimes(5);
       });
     });
   });

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -21,7 +21,6 @@ export default class Uploader {
   }
 
   private async uploadFile(entry: readdirp.EntryInfo) {
-    const readStream = fs.createReadStream(entry.fullPath);
     const destination = this.destination
       ? `${this.destination}/${entry.path}`
       : entry.path;
@@ -30,6 +29,7 @@ export default class Uploader {
     );
     return promiseRetry(
       async (attempt) => {
+        const readStream = fs.createReadStream(entry.fullPath);
         const response = await fetch(
           `https://${this.storageEndpoint}/${this.storageName}/${destination}`,
           {


### PR DESCRIPTION
We've seen a few issues with retries uploading zero-byte files instead, which seems to be caused by re-using the file stream across upload attempts (i.e. the file has been read already when it's retried).

This PR creates the `fs.ReadStream` every attempt, so we're not reading from a closed/finished stream.